### PR TITLE
Feat: RWA Registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ out/
 node_modules/
 .env*
 !.env.example
+lcov.*
+report/

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ clean:; forge clean
 update:; forge update
 # Build & test
 build:; forge build
-test:; forge test # --ffi # enable if you need the `ffi` cheat code on HEVM
+test:; forge test ${args} # --ffi # enable if you need the `ffi` cheat code on HEVM
 
 flatten:; forge flatten --source-file src/DappTemplate.sol
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,4 +3,5 @@ src = 'src'
 test = 'src'
 out = 'out'
 libs = ['lib']
+gas_reports = ["*"]
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/src/RwaRegistry.sol
+++ b/src/RwaRegistry.sol
@@ -16,4 +16,145 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.14;
 
-contract RwaRegistry {}
+/**
+ * @title MIP-21 RWA Registry
+ * @author Henrique Barcelos <henrique@clio.finance>
+ * @notice Registry for different MIP-21 deals onboarded into MCD.
+ */
+contract RwaRegistry {
+  /// @notice Addresses with admin access on this contract. `wards[usr]`
+  mapping(address => uint256) public wards;
+
+  /// @notice Maps a RWA ilk to the related info. `ilksToInfo[ilk]`
+  mapping(bytes32 => Info) public ilkToInfo;
+
+  /// @notice List of all RWA ilks in this registry.
+  bytes32[] internal ilks;
+
+  /**
+   * @notice `usr` was granted admin access.
+   * @param usr The user address.
+   */
+  event Rely(address indexed usr);
+  /**
+   * @notice `usr` admin access was revoked.
+   * @param usr The user address.
+   */
+  event Deny(address indexed usr);
+
+  /// @notice Revert reason when `msg.sender` does not have the required admin access.
+  error NotAuthorized();
+
+  /**
+   * @notice Revert reason when trying to add info for an ilk which already exists.
+   * @param ilk The ilk being added.
+   */
+  error IlkAlreadyExists(bytes32 ilk);
+
+  /**
+   * @notice Revert reason when adding an OutputConduit different than the one returned by the Urn
+   * @param urn The urn address.
+   */
+  error UrnOutputConduitMismatch(address urn);
+
+  /**
+   * @notice Only addresses with admin access can call methods with this modifier.
+   */
+  modifier auth() {
+    if (wards[msg.sender] != 1) {
+      revert NotAuthorized();
+    }
+    _;
+  }
+
+  // MIP-21 Architeture Components
+  struct Component {
+    address addr; // address of the component of the deal.
+    uint96 variant; // variant of the component implementation (1, 2, ...). Any reserved values should be documented.
+  }
+
+  // Information about a RWA Deal
+  struct Info {
+    uint256 pos; // index in ilks array
+    Component token; // address and variant of the RwaToken for the deal. [required]
+    Component urn; // address and variant of the RwaUrn for the deal. [required]
+    Component liquidationOracle; // address and variant of the RwaLiquidationOracle for the deal. [required]
+    Component outputConduit; // address and variant of the RwaOutputConduit for the deal; variant should be `type(uint96).max` when it should be treated as an opaque address [required]
+    Component inputConduit; // address and variant of the RwaInput for the deal. [optional]
+    Component jar; // address and variant of the RwaJar for the deal. [optional]
+  }
+
+  /// @notice The deployer of the contract gains admin access to it.
+  constructor() {
+    wards[msg.sender] = 1;
+    emit Rely(msg.sender);
+  }
+
+  /*//////////////////////////////////
+              Authorization
+  //////////////////////////////////*/
+
+  /**
+   * @notice Grants `usr` admin access to this contract.
+   * @param usr The user address.
+   */
+  function rely(address usr) external auth {
+    wards[usr] = 1;
+    emit Rely(usr);
+  }
+
+  /**
+   * @notice Revokes `usr` admin access from this contract.
+   * @param usr The user address.
+   */
+  function deny(address usr) external auth {
+    wards[usr] = 0;
+    emit Deny(usr);
+  }
+
+  /**
+   * @notice Adds the components of MIP-21 associated to an `ilk_`
+   * @param ilk_ The ilk name.
+   * @param token_ address and variant of the RwaToken for the deal. [required]
+   * @param urn_ address and variant of the RwaUrn for the deal. [required]
+   * @param liquidationOracle_ address and variant of the RwaLiquidationOracle for the deal. [required]
+   * @param outputConduit_ address and variant of the RwaOutputConduit for the deal;
+   *        variant should be `type(uint96).max` when it should be treated as an opaque address [required]
+   * @param _inputConduit address and variant of the RwaInput for the deal [optional];
+   *        Provide [address(0), 0] if the component was not deployed.
+   * @param _jar address and variant of the RwaJar for the deal [optional];
+   *        Provide [address(0), 0] if the component was not deployed.
+   */
+  function add(
+    bytes32 ilk_,
+    Component calldata token_,
+    Component calldata urn_,
+    Component calldata liquidationOracle_,
+    Component calldata outputConduit_,
+    Component calldata inputConduit_,
+    Component calldata jar_
+  ) external auth {
+    if (ilkToInfo[ilk_].token.addr != address(0)) {
+      revert IlkAlreadyExists(ilk_);
+    }
+
+    if (RwaUrnLike(urn_.addr).outputConduit() != outputConduit_.addr) {
+      revert UrnOutputConduitMismatch(urn_.addr);
+    }
+
+    ilks.push(ilk_);
+    Info storage info = ilkToInfo[ilk_];
+
+    info.pos = ilks.length - 1;
+    info.token = token_;
+    info.urn = urn_;
+    info.liquidationOracle = liquidationOracle_;
+    info.outputConduit = outputConduit_;
+    info.inputConduit = inputConduit_;
+    info.jar = jar_;
+  }
+}
+
+interface RwaUrnLike {
+  function outputConduit() external view returns (address);
+}

--- a/src/RwaRegistry.t.sol
+++ b/src/RwaRegistry.t.sol
@@ -30,7 +30,7 @@ contract RwaRegistryTest is Test {
      Supported Components Management
   //////////////////////////////////*/
 
-  function testShouldAddDefaultSupportedComponentsDuringDeployment() public {
+  function testAddDefaultSupportedComponentsDuringDeployment() public {
     assertEq(reg.isSupportedComponent("token"), 1);
     assertEq(reg.isSupportedComponent("urn"), 1);
     assertEq(reg.isSupportedComponent("liquidationOracle"), 1);
@@ -45,18 +45,25 @@ contract RwaRegistryTest is Test {
     assertEq(reg.isSupportedComponent("somethingElse"), 1);
   }
 
-  function testRevertUnautorizedAddressAddsSupportedComponent() public {
+  function testFuzzRevertUnautorizedAddSupportedComponent(address sender_) public {
     vm.expectRevert(RwaRegistry.Unauthorized.selector);
 
-    vm.prank(address(0x1337));
+    vm.prank(sender_);
     reg.addSupportedComponent("anything");
+  }
+
+  function testFuzzRevertAddExistingSupportedComponent(bytes32 componentName_) public {
+    reg.addSupportedComponent(componentName_);
+
+    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.ComponentAlreadySupported.selector, componentName_));
+    reg.addSupportedComponent(componentName_);
   }
 
   /*//////////////////////////////////
      Deals & Components Management
   //////////////////////////////////*/
 
-  function testFuzzShouldAddDealAndItsComponents(
+  function testFuzzAddDealAndItsComponents(
     bytes32 ilk_,
     address token_,
     address urn_,
@@ -107,7 +114,7 @@ contract RwaRegistryTest is Test {
     assertEq(actualComponents[5].variant, expectedComponents[5].variant, "Component variant mismatch: jar");
   }
 
-  function testFuzzShouldAddDealAndItsComponentsAsTuples(
+  function testFuzzAddDealAndItsComponentsAsTuple(
     bytes32 ilk_,
     address token_,
     address urn_
@@ -139,5 +146,52 @@ contract RwaRegistryTest is Test {
 
     assertEq(actualComponents[0].variant, variants[0], "Component variant mismatch: token");
     assertEq(actualComponents[1].variant, variants[1], "Component variant mismatch: urn");
+  }
+
+  function testUpdateDealComponent(
+    bytes32 ilk_,
+    address token_,
+    uint256 variant_
+  ) public {
+    RwaRegistry.Component memory originalComponent = RwaRegistry.Component({
+      name: "token",
+      addr: address(0x1337),
+      variant: 1
+    });
+    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
+    components[0] = originalComponent;
+    reg.add(ilk_, components);
+
+    RwaRegistry.Component memory expectedComponent = RwaRegistry.Component({
+      name: "token",
+      addr: token_,
+      variant: variant_
+    });
+    reg.file(ilk_, "component", expectedComponent);
+
+    RwaRegistry.Component memory actualComponent = reg.getComponent(ilk_, "token");
+    assertEq(actualComponent.addr, expectedComponent.addr, "Component address mismatch: token");
+    assertEq(actualComponent.variant, expectedComponent.variant, "Component variant mismatch: token");
+  }
+
+  function testUpdateDealComponentAsTuple(
+    bytes32 ilk_,
+    address token_,
+    uint256 variant_
+  ) public {
+    RwaRegistry.Component memory originalComponent = RwaRegistry.Component({
+      name: "token",
+      addr: address(0x1337),
+      variant: 1
+    });
+    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
+    components[0] = originalComponent;
+    reg.add(ilk_, components);
+
+    reg.file(ilk_, "component", "token", token_, variant_);
+
+    (, address actualAddr, uint256 actualVariant) = reg.getComponentTuple(ilk_, "token");
+    assertEq(actualAddr, token_, "Component address mismatch: token");
+    assertEq(actualVariant, variant_, "Component variant mismatch: token");
   }
 }

--- a/src/RwaRegistry.t.sol
+++ b/src/RwaRegistry.t.sol
@@ -27,10 +27,27 @@ contract RwaRegistryTest is Test {
   }
 
   /*//////////////////////////////////
+              Authorization
+  //////////////////////////////////*/
+
+  function testRely() public {
+    reg.rely(address(0x1337));
+
+    assertEq(reg.wards(address(0x1337)), 1);
+  }
+
+  function testDeny() public {
+    reg.deny(address(this));
+
+    assertEq(reg.wards(address(this)), 0);
+  }
+
+  /*//////////////////////////////////
      Supported Components Management
   //////////////////////////////////*/
 
   function testAddDefaultSupportedComponentsDuringDeployment() public {
+    assertEq(reg.listSupportedComponents().length, 6);
     assertEq(reg.isSupportedComponent("token"), 1);
     assertEq(reg.isSupportedComponent("urn"), 1);
     assertEq(reg.isSupportedComponent("liquidationOracle"), 1);
@@ -45,33 +62,50 @@ contract RwaRegistryTest is Test {
     assertEq(reg.isSupportedComponent("somethingElse"), 1);
   }
 
-  function testFuzzRevertUnautorizedAddSupportedComponent(address sender_) public {
-    vm.expectRevert(RwaRegistry.Unauthorized.selector);
+  function testFuzzRevertAddExistingSupportedComponent() public {
+    // bytes32 componentName_
 
-    vm.prank(sender_);
-    reg.addSupportedComponent("anything");
-  }
-
-  function testFuzzRevertAddExistingSupportedComponent(bytes32 componentName_) public {
+    bytes32 componentName_ = "anything";
     reg.addSupportedComponent(componentName_);
 
     vm.expectRevert(abi.encodeWithSelector(RwaRegistry.ComponentAlreadySupported.selector, componentName_));
     reg.addSupportedComponent(componentName_);
   }
 
+  function testFuzzRevertUnautorizedAddSupportedComponent() public {
+    // address sender_
+    // if (sender_ == address(this)) {
+    //   return;
+    // }
+    address sender_ = address(0x1337);
+
+    vm.expectRevert(RwaRegistry.Unauthorized.selector);
+    vm.prank(sender_);
+
+    reg.addSupportedComponent("anything");
+  }
+
   /*//////////////////////////////////
      Deals & Components Management
   //////////////////////////////////*/
 
-  function testFuzzAddDealAndItsComponents(
-    bytes32 ilk_,
-    address token_,
-    address urn_,
-    address liquidationOracle_,
-    address outputConduit_,
-    address inputConduit_,
-    address jar_
-  ) public {
+  function testFuzzAddDealAndComponents() public {
+    // bytes32 ilk_,
+    // address token_,
+    // address urn_,
+    // address liquidationOracle_,
+    // address outputConduit_,
+    // address inputConduit_,
+    // address jar_
+
+    bytes32 ilk_ = "RWA1337-a";
+    address token_ = address(0x1337);
+    address urn_ = address(0x2448);
+    address liquidationOracle_ = address(0x3559);
+    address outputConduit_ = address(0x466a);
+    address inputConduit_ = address(0x577b);
+    address jar_ = address(0x688c);
+
     RwaRegistry.Component[] memory expectedComponents = new RwaRegistry.Component[](6);
 
     expectedComponents[0] = RwaRegistry.Component({name: "token", addr: token_, variant: 1});
@@ -114,11 +148,33 @@ contract RwaRegistryTest is Test {
     assertEq(actualComponents[5].variant, expectedComponents[5].variant, "Component variant mismatch: jar");
   }
 
-  function testFuzzAddDealAndItsComponentsAsTuple(
-    bytes32 ilk_,
-    address token_,
-    address urn_
-  ) public {
+  function testRevertAddDealWithUnsupportedComponent() public {
+    // bytes32 ilk_,
+    // address token_,
+    // address someAddr,
+
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x1337);
+    address someAddr_ = address(0x2448);
+
+    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](2);
+
+    components[0] = RwaRegistry.Component({name: "token", addr: token_, variant: 1});
+    components[1] = RwaRegistry.Component({name: "something", addr: someAddr_, variant: 1});
+
+    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.UnsupportedComponent.selector, components[1].name));
+    reg.add(ilk_, components);
+  }
+
+  function testFuzzAddDealAndComponentsAsTuple() public {
+    // bytes32 ilk_,
+    // address token_,
+    // address urn_
+
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x1337);
+    address urn_ = address(0x2448);
+
     bytes32[] memory names = new bytes32[](2);
     names[0] = "token";
     names[1] = "urn";
@@ -134,25 +190,251 @@ contract RwaRegistryTest is Test {
     reg.add(ilk_, names, addrs, variants);
 
     (RwaRegistry.DealStatus status, ) = reg.ilkToDeal(ilk_);
-    RwaRegistry.Component[] memory actualComponents = reg.listComponentsOf(ilk_);
+    (bytes32[] memory actualNames, address[] memory actualAddrs, uint256[] memory actualVariants) = reg
+      .listComponentsTupleOf(ilk_);
 
     assertEq(uint256(status), uint256(RwaRegistry.DealStatus.ACTIVE));
 
-    assertEq(actualComponents[0].name, names[0], "Component mismatch: token");
-    assertEq(actualComponents[1].name, names[1], "Component mismatch: urn");
+    assertEq(actualNames[0], names[0], "Component mismatch: token");
+    assertEq(actualNames[1], names[1], "Component mismatch: urn");
 
-    assertEq(actualComponents[0].addr, addrs[0], "Component address mismatch: token");
-    assertEq(actualComponents[1].addr, addrs[1], "Component address mismatch: urn");
+    assertEq(actualAddrs[0], addrs[0], "Component address mismatch: token");
+    assertEq(actualAddrs[1], addrs[1], "Component address mismatch: urn");
 
-    assertEq(actualComponents[0].variant, variants[0], "Component variant mismatch: token");
-    assertEq(actualComponents[1].variant, variants[1], "Component variant mismatch: urn");
+    assertEq(actualVariants[0], variants[0], "Component variant mismatch: token");
+    assertEq(actualVariants[1], variants[1], "Component variant mismatch: urn");
   }
 
-  function testUpdateDealComponent(
-    bytes32 ilk_,
-    address token_,
-    uint256 variant_
-  ) public {
+  function testRevertAddDealWithUnsupportedComponentAsTuple() public {
+    // bytes32 ilk_,
+    // address token_,
+    // address someAddr,
+
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x1337);
+    address someAddr_ = address(0x2448);
+
+    bytes32[] memory names = new bytes32[](2);
+    names[0] = "token";
+    names[1] = "something";
+
+    address[] memory addrs = new address[](2);
+    addrs[0] = token_;
+    addrs[1] = someAddr_;
+
+    uint256[] memory variants = new uint256[](2);
+    variants[0] = 1;
+    variants[1] = 1;
+
+    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.UnsupportedComponent.selector, names[1]));
+    reg.add(ilk_, names, addrs, variants);
+  }
+
+  function testRevertAddDealWithComponentsAsTupleWithMismatchingParams() public {
+    // bytes32 ilk_,
+    // address token_,
+    // address urn_
+
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x1337);
+    address urn_ = address(0x2448);
+
+    bytes32[] memory names = new bytes32[](1);
+    names[0] = "token";
+
+    address[] memory addrs = new address[](2);
+    addrs[0] = token_;
+    addrs[1] = urn_;
+
+    uint256[] memory variants = new uint256[](2);
+    variants[0] = 1;
+    variants[1] = 1;
+
+    vm.expectRevert(RwaRegistry.MismatchingComponentParams.selector);
+    reg.add(ilk_, names, addrs, variants);
+  }
+
+  function testRevertListComponentsOfUnexistingDeal() public {
+    // bytes32 ilk_
+
+    bytes32 ilk_ = "RWA1337-A";
+
+    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.DealDoesNotExist.selector, ilk_));
+    reg.listComponentsOf(ilk_);
+  }
+
+  function testRevertListComponentsTupleOfUnexistingDeal() public {
+    // bytes32 ilk_
+
+    bytes32 ilk_ = "RWA1337-A";
+
+    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.DealDoesNotExist.selector, ilk_));
+    reg.listComponentsTupleOf(ilk_);
+  }
+
+  function testFuzzAddDealWithEmptyComponentList() public {
+    // bytes32 ilk_
+
+    bytes32 ilk_ = "RWA1337-A";
+
+    RwaRegistry.Component[] memory components;
+    reg.add(ilk_, components);
+
+    (RwaRegistry.DealStatus status, ) = reg.ilkToDeal(ilk_);
+    RwaRegistry.Component[] memory actualComponents = reg.listComponentsOf(ilk_);
+
+    assertEq(uint256(status), uint256(RwaRegistry.DealStatus.ACTIVE));
+    assertTrue(actualComponents.length == 0);
+  }
+
+  function testFuzzAddDealWithNoComponents() public {
+    // bytes32 ilk_
+
+    bytes32 ilk_ = "RWA1337-A";
+
+    reg.add(ilk_);
+
+    (RwaRegistry.DealStatus status, ) = reg.ilkToDeal(ilk_);
+    RwaRegistry.Component[] memory actualComponents = reg.listComponentsOf(ilk_);
+
+    assertEq(uint256(status), uint256(RwaRegistry.DealStatus.ACTIVE));
+    assertTrue(actualComponents.length == 0);
+  }
+
+  function testRevertAddExistingDeal() public {
+    // bytes32 ilk_,
+
+    bytes32 ilk_ = "RWA1337-A";
+    reg.add(ilk_);
+
+    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.DealAlreadyExists.selector, ilk_));
+    reg.add(ilk_);
+  }
+
+  function testFuzzRevertUnautorizedAddDeal() public {
+    // address sender_,
+    // bytes32 ilk_,
+    // address token_
+
+    // if (sender_ == address(this)) {
+    //   return;
+    // }
+
+    address sender_ = address(0x1337);
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x2448);
+
+    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
+    components[0] = RwaRegistry.Component({name: "token", addr: token_, variant: 1});
+
+    vm.expectRevert(RwaRegistry.Unauthorized.selector);
+    vm.prank(sender_);
+
+    reg.add(ilk_, components);
+  }
+
+  function testFuzzListAllDealIlks() public {
+    // bytes32 ilk1_, bytes32 ilk2_
+    // if (ilk1_ == ilk2_) {
+    //   return;
+    // }
+
+    bytes32 ilk1_ = "RWA1337-A";
+    bytes32 ilk2_ = "RWA2448-A";
+
+    reg.add(ilk1_);
+    reg.add(ilk2_);
+
+    bytes32[] memory actualIlks = reg.list();
+
+    bytes32[] memory expectedIlks = new bytes32[](2);
+    expectedIlks[0] = ilk1_;
+    expectedIlks[1] = ilk2_;
+
+    assertEq(actualIlks[0], expectedIlks[0]);
+    assertEq(actualIlks[1], expectedIlks[1]);
+  }
+
+  function testFuzziCountAllDealIlks() public {
+    // bytes32[] memory ilks_
+    // if (ilks_.length == 0) {
+    //   return;
+    // }
+
+    bytes32[] memory ilks_ = new bytes32[](3);
+    ilks_[0] = "RWA1337-A";
+    ilks_[1] = "RWA2448-A";
+    ilks_[2] = "RWA3559-A";
+
+    uint256 duplicates = 0;
+    for (uint256 i = 0; i < ilks_.length; i++) {
+      try reg.add(ilks_[i]) {} catch {
+        duplicates++;
+      }
+    }
+
+    uint256 count = reg.count();
+
+    uint256 expected = ilks_.length - duplicates;
+    assertEq(count, expected);
+  }
+
+  function testFuzzAddNewDealComponent() public {
+    // bytes32 ilk_,
+    // address token_,
+    // address urn_,
+    // uint256 variant_
+
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x1337);
+    address urn_ = address(0x3549);
+    uint256 variant_ = 0x2830;
+
+    RwaRegistry.Component memory originalComponent = RwaRegistry.Component({name: "token", addr: token_, variant: 1});
+    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
+    components[0] = originalComponent;
+    reg.add(ilk_, components);
+
+    RwaRegistry.Component memory newComponent = RwaRegistry.Component({name: "urn", addr: urn_, variant: variant_});
+    reg.file(ilk_, "component", newComponent);
+
+    RwaRegistry.Component memory actualComponent = reg.getComponent(ilk_, "urn");
+    assertEq(actualComponent.addr, newComponent.addr, "Component address mismatch");
+    assertEq(actualComponent.variant, newComponent.variant, "Component variant mismatch");
+  }
+
+  function testFuzzAddNewDealComponentAsTuple() public {
+    // bytes32 ilk_,
+    // address token_,
+    // address urn_,
+    // uint256 variant_
+
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x1337);
+    address urn_ = address(0x3549);
+    uint256 variant_ = 0x2830;
+
+    RwaRegistry.Component memory originalComponent = RwaRegistry.Component({name: "token", addr: token_, variant: 1});
+    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
+    components[0] = originalComponent;
+    reg.add(ilk_, components);
+
+    reg.file(ilk_, "component", "urn", urn_, variant_);
+
+    (, address actualAddr, uint256 actualVariant) = reg.getComponentTuple(ilk_, "urn");
+    assertEq(actualAddr, urn_, "Component address mismatch");
+    assertEq(actualVariant, variant_, "Component variant mismatch");
+  }
+
+  function testFuzzUpdateDealComponent() public {
+    // bytes32 ilk_,
+    // address token_,
+    // uint256 variant_
+
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x2448);
+    uint256 variant_ = 0x2830;
+
     RwaRegistry.Component memory originalComponent = RwaRegistry.Component({
       name: "token",
       addr: address(0x1337),
@@ -170,15 +452,56 @@ contract RwaRegistryTest is Test {
     reg.file(ilk_, "component", expectedComponent);
 
     RwaRegistry.Component memory actualComponent = reg.getComponent(ilk_, "token");
-    assertEq(actualComponent.addr, expectedComponent.addr, "Component address mismatch: token");
-    assertEq(actualComponent.variant, expectedComponent.variant, "Component variant mismatch: token");
+    assertEq(actualComponent.addr, expectedComponent.addr, "Component address mismatch");
+    assertEq(actualComponent.variant, expectedComponent.variant, "Component variant mismatch");
   }
 
-  function testUpdateDealComponentAsTuple(
-    bytes32 ilk_,
-    address token_,
-    uint256 variant_
-  ) public {
+  function testReverGetComponentForUnexistingDeal() public {
+    // bytes32 ilk_,
+    // address token_,
+    // uint256 variant_
+
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x2448);
+    uint256 variant_ = 0x2830;
+
+    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: token_, variant: variant_});
+    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
+    components[0] = component;
+    reg.add(ilk_, components);
+
+    bytes32 wrongIlk = "RWA2448-A";
+    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.DealDoesNotExist.selector, wrongIlk));
+    reg.getComponent(wrongIlk, "token");
+  }
+
+  function testReverGetUnexistentComponentForExistingDeal() public {
+    // bytes32 ilk_,
+    // address token_,
+    // uint256 variant_
+
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x2448);
+    uint256 variant_ = 0x2830;
+
+    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: token_, variant: variant_});
+    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
+    components[0] = component;
+    reg.add(ilk_, components);
+
+    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.ComponentDoesNotExist.selector, ilk_, bytes32("urn")));
+    reg.getComponent(ilk_, "urn");
+  }
+
+  function testFuzzUpdateDealComponentAsTuple() public {
+    // bytes32 ilk_,
+    // address token_,
+    // uint256 variant_
+
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x2448);
+    uint256 variant_ = 0x2830;
+
     RwaRegistry.Component memory originalComponent = RwaRegistry.Component({
       name: "token",
       addr: address(0x1337),
@@ -191,7 +514,163 @@ contract RwaRegistryTest is Test {
     reg.file(ilk_, "component", "token", token_, variant_);
 
     (, address actualAddr, uint256 actualVariant) = reg.getComponentTuple(ilk_, "token");
-    assertEq(actualAddr, token_, "Component address mismatch: token");
-    assertEq(actualVariant, variant_, "Component variant mismatch: token");
+    assertEq(actualAddr, token_, "Component address mismatch");
+    assertEq(actualVariant, variant_, "Component variant mismatch");
+  }
+
+  function testReverUpdateUnexistingParameter() public {
+    // bytes32 ilk_,
+    // address token_,
+    // uint256 variant_
+
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x2448);
+    uint256 variant_ = 0x2830;
+
+    reg.add(ilk_);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(RwaRegistry.UnsupportedParameter.selector, ilk_, bytes32("unexistingParameter"))
+    );
+    reg.file(ilk_, "unexistingParameter", RwaRegistry.Component({name: "token", addr: token_, variant: variant_}));
+  }
+
+  function testReverUpdateUnexistingParameterAsTuple() public {
+    // bytes32 ilk_,
+    // address token_,
+    // uint256 variant_
+
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x2448);
+    uint256 variant_ = 0x2830;
+
+    reg.add(ilk_);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(RwaRegistry.UnsupportedParameter.selector, ilk_, bytes32("unexistingParameter"))
+    );
+    reg.file(ilk_, "unexistingParameter", "token", token_, variant_);
+  }
+
+  function testReverGetComponentAsTupleForUnexistingDeal() public {
+    // bytes32 ilk_,
+    // address token_,
+    // uint256 variant_
+
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x2448);
+    uint256 variant_ = 0x2830;
+
+    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: token_, variant: variant_});
+    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
+    components[0] = component;
+    reg.add(ilk_, components);
+
+    bytes32 wrongIlk = "RWA2448-A";
+    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.DealDoesNotExist.selector, wrongIlk));
+    reg.getComponentTuple(wrongIlk, "token");
+  }
+
+  function testReverGetUnexistentComponentAsTupleForExistingDeal() public {
+    // bytes32 ilk_,
+    // address token_,
+    // uint256 variant_
+
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x2448);
+    uint256 variant_ = 0x2830;
+
+    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: token_, variant: variant_});
+    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
+    components[0] = component;
+    reg.add(ilk_, components);
+
+    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.ComponentDoesNotExist.selector, ilk_, bytes32("urn")));
+    reg.getComponentTuple(ilk_, "urn");
+  }
+
+  function testFuzzRevertUnautorizedUpdateDeal() public {
+    // address sender_,
+    // bytes32 ilk_,
+    // address token_
+
+    // if (sender_ == address(this)) {
+    //   return;
+    // }
+
+    address sender_ = address(0x1337);
+    bytes32 ilk_ = "RWA1337-A";
+    address token_ = address(0x2448);
+
+    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
+    components[0] = RwaRegistry.Component({name: "token", addr: token_, variant: 1});
+    reg.add(ilk_, components);
+
+    vm.expectRevert(RwaRegistry.Unauthorized.selector);
+    vm.prank(sender_);
+
+    reg.file(ilk_, "component", RwaRegistry.Component({name: "token", addr: address(0x1337), variant: 1337}));
+  }
+
+  function testFuzzFinalizeComponent() public {
+    // bytes32 ilk_
+
+    bytes32 ilk_ = "RWA1337-A";
+
+    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: address(0x1337), variant: 1});
+    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
+    components[0] = component;
+    reg.add(ilk_, components);
+
+    reg.finalize(ilk_);
+
+    (RwaRegistry.DealStatus status, ) = reg.ilkToDeal(ilk_);
+
+    assertEq(uint256(status), uint256(RwaRegistry.DealStatus.FINALIZED));
+  }
+
+  function testRevertFinalizeUnexistingComponent() public {
+    // bytes32 ilk_
+
+    bytes32 ilk_ = "RWA1337-A";
+
+    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: address(0x1337), variant: 1});
+    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
+    components[0] = component;
+    reg.add(ilk_, components);
+
+    bytes32 wrongIlk = "RWA2448-A";
+    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.DealIsNotActive.selector, wrongIlk));
+    reg.finalize(wrongIlk);
+  }
+
+  function testFuzzRevertUpdateFinalizedComponent() public {
+    // bytes32 ilk_
+
+    bytes32 ilk_ = "RWA1337-A";
+
+    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: address(0x1337), variant: 1});
+    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
+    components[0] = component;
+    reg.add(ilk_, components);
+    reg.finalize(ilk_);
+
+    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.DealIsNotActive.selector, ilk_));
+    reg.file(ilk_, "component", RwaRegistry.Component({name: "token", addr: address(0x2448), variant: 2}));
+  }
+
+  function testFuzzRevertUpdateFinalizedComponentAsTuple() public {
+    // bytes32 ilk_
+
+    bytes32 ilk_ = "RWA1337-A";
+
+    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: address(0x1337), variant: 1});
+    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
+    components[0] = component;
+    reg.add(ilk_, components);
+    reg.finalize(ilk_);
+
+    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.DealIsNotActive.selector, ilk_));
+    reg.file(ilk_, "component", "token", address(0x2448), 2);
   }
 }

--- a/src/RwaRegistry.t.sol
+++ b/src/RwaRegistry.t.sol
@@ -51,4 +51,93 @@ contract RwaRegistryTest is Test {
     vm.prank(address(0x1337));
     reg.addSupportedComponent("anything");
   }
+
+  /*//////////////////////////////////
+     Deals & Components Management
+  //////////////////////////////////*/
+
+  function testFuzzShouldAddDealAndItsComponents(
+    bytes32 ilk_,
+    address token_,
+    address urn_,
+    address liquidationOracle_,
+    address outputConduit_,
+    address inputConduit_,
+    address jar_
+  ) public {
+    RwaRegistry.Component[] memory expectedComponents = new RwaRegistry.Component[](6);
+
+    expectedComponents[0] = RwaRegistry.Component({name: "token", addr: token_, variant: 1});
+    expectedComponents[1] = RwaRegistry.Component({name: "urn", addr: urn_, variant: 1});
+    expectedComponents[2] = RwaRegistry.Component({name: "liquidationOracle", addr: liquidationOracle_, variant: 1});
+    expectedComponents[3] = RwaRegistry.Component({name: "outputConduit", addr: outputConduit_, variant: 1});
+    expectedComponents[4] = RwaRegistry.Component({name: "inputConduit", addr: inputConduit_, variant: 1});
+    expectedComponents[5] = RwaRegistry.Component({name: "jar", addr: jar_, variant: 1});
+
+    reg.add(ilk_, expectedComponents);
+
+    (RwaRegistry.DealStatus status, ) = reg.ilkToDeal(ilk_);
+    RwaRegistry.Component[] memory actualComponents = reg.listComponentsOf(ilk_);
+
+    assertEq(uint256(status), uint256(RwaRegistry.DealStatus.ACTIVE));
+
+    assertEq(actualComponents[0].name, expectedComponents[0].name, "Component mismatch: token");
+    assertEq(actualComponents[1].name, expectedComponents[1].name, "Component mismatch: urn");
+    assertEq(actualComponents[2].name, expectedComponents[2].name, "Component mismatch: liquidationOracle");
+    assertEq(actualComponents[3].name, expectedComponents[3].name, "Component mismatch: outputConduit");
+    assertEq(actualComponents[4].name, expectedComponents[4].name, "Component mismatch: inputConduit");
+    assertEq(actualComponents[5].name, expectedComponents[5].name, "Component mismatch: jar");
+
+    assertEq(actualComponents[0].addr, expectedComponents[0].addr, "Component address mismatch: token");
+    assertEq(actualComponents[1].addr, expectedComponents[1].addr, "Component address mismatch: urn");
+    assertEq(actualComponents[2].addr, expectedComponents[2].addr, "Component address mismatch: liquidationOracle");
+    assertEq(actualComponents[3].addr, expectedComponents[3].addr, "Component address mismatch: outputConduit");
+    assertEq(actualComponents[4].addr, expectedComponents[4].addr, "Component address mismatch: inputConduit");
+    assertEq(actualComponents[5].addr, expectedComponents[5].addr, "Component address mismatch: jar");
+
+    assertEq(actualComponents[0].variant, expectedComponents[0].variant, "Component variant mismatch: token");
+    assertEq(actualComponents[1].variant, expectedComponents[1].variant, "Component variant mismatch: urn");
+    assertEq(
+      actualComponents[2].variant,
+      expectedComponents[2].variant,
+      "Component variant mismatch: liquidationOracle"
+    );
+    assertEq(actualComponents[3].variant, expectedComponents[3].variant, "Component variant mismatch: outputConduit");
+    assertEq(actualComponents[4].variant, expectedComponents[4].variant, "Component variant mismatch: inputConduit");
+    assertEq(actualComponents[5].variant, expectedComponents[5].variant, "Component variant mismatch: jar");
+  }
+
+  function testFuzzShouldAddDealAndItsComponentsAsTuples(
+    bytes32 ilk_,
+    address token_,
+    address urn_
+  ) public {
+    bytes32[] memory names = new bytes32[](2);
+    names[0] = "token";
+    names[1] = "urn";
+
+    address[] memory addrs = new address[](2);
+    addrs[0] = token_;
+    addrs[1] = urn_;
+
+    uint256[] memory variants = new uint256[](2);
+    variants[0] = 1;
+    variants[1] = 1;
+
+    reg.add(ilk_, names, addrs, variants);
+
+    (RwaRegistry.DealStatus status, ) = reg.ilkToDeal(ilk_);
+    RwaRegistry.Component[] memory actualComponents = reg.listComponentsOf(ilk_);
+
+    assertEq(uint256(status), uint256(RwaRegistry.DealStatus.ACTIVE));
+
+    assertEq(actualComponents[0].name, names[0], "Component mismatch: token");
+    assertEq(actualComponents[1].name, names[1], "Component mismatch: urn");
+
+    assertEq(actualComponents[0].addr, addrs[0], "Component address mismatch: token");
+    assertEq(actualComponents[1].addr, addrs[1], "Component address mismatch: urn");
+
+    assertEq(actualComponents[0].variant, variants[0], "Component variant mismatch: token");
+    assertEq(actualComponents[1].variant, variants[1], "Component variant mismatch: urn");
+  }
 }

--- a/src/RwaRegistry.t.sol
+++ b/src/RwaRegistry.t.sol
@@ -62,7 +62,7 @@ contract RwaRegistryTest is Test {
     assertEq(reg.isSupportedComponent("somethingElse"), 1);
   }
 
-  function testFuzzRevertAddExistingSupportedComponent() public {
+  function testRevertAddExistingSupportedComponent() public {
     // bytes32 componentName_
 
     bytes32 componentName_ = "anything";
@@ -72,7 +72,7 @@ contract RwaRegistryTest is Test {
     reg.addSupportedComponent(componentName_);
   }
 
-  function testFuzzRevertUnautorizedAddSupportedComponent() public {
+  function testRevertUnautorizedAddSupportedComponent() public {
     // address sender_
     // if (sender_ == address(this)) {
     //   return;
@@ -89,7 +89,7 @@ contract RwaRegistryTest is Test {
      Deals & Components Management
   //////////////////////////////////*/
 
-  function testFuzzAddDealAndComponents() public {
+  function testAddDealAndComponents() public {
     // bytes32 ilk_,
     // address token_,
     // address urn_,
@@ -166,7 +166,7 @@ contract RwaRegistryTest is Test {
     reg.add(ilk_, components);
   }
 
-  function testFuzzAddDealAndComponentsAsTuple() public {
+  function testAddDealAndComponentsAsTuple() public {
     // bytes32 ilk_,
     // address token_,
     // address urn_
@@ -272,7 +272,7 @@ contract RwaRegistryTest is Test {
     reg.listComponentsTupleOf(ilk_);
   }
 
-  function testFuzzAddDealWithEmptyComponentList() public {
+  function testAddDealWithEmptyComponentList() public {
     // bytes32 ilk_
 
     bytes32 ilk_ = "RWA1337-A";
@@ -287,7 +287,7 @@ contract RwaRegistryTest is Test {
     assertTrue(actualComponents.length == 0);
   }
 
-  function testFuzzAddDealWithNoComponents() public {
+  function testAddDealWithNoComponents() public {
     // bytes32 ilk_
 
     bytes32 ilk_ = "RWA1337-A";
@@ -311,7 +311,7 @@ contract RwaRegistryTest is Test {
     reg.add(ilk_);
   }
 
-  function testFuzzRevertUnautorizedAddDeal() public {
+  function testRevertUnautorizedAddDeal() public {
     // address sender_,
     // bytes32 ilk_,
     // address token_
@@ -333,7 +333,7 @@ contract RwaRegistryTest is Test {
     reg.add(ilk_, components);
   }
 
-  function testFuzzListAllDealIlks() public {
+  function testListAllDealIlks() public {
     // bytes32 ilk1_, bytes32 ilk2_
     // if (ilk1_ == ilk2_) {
     //   return;
@@ -355,7 +355,7 @@ contract RwaRegistryTest is Test {
     assertEq(actualIlks[1], expectedIlks[1]);
   }
 
-  function testFuzziCountAllDealIlks() public {
+  function testiCountAllDealIlks() public {
     // bytes32[] memory ilks_
     // if (ilks_.length == 0) {
     //   return;
@@ -379,7 +379,7 @@ contract RwaRegistryTest is Test {
     assertEq(count, expected);
   }
 
-  function testFuzzAddNewDealComponent() public {
+  function testAddNewDealComponent() public {
     // bytes32 ilk_,
     // address token_,
     // address urn_,
@@ -403,7 +403,7 @@ contract RwaRegistryTest is Test {
     assertEq(actualComponent.variant, newComponent.variant, "Component variant mismatch");
   }
 
-  function testFuzzAddNewDealComponentAsTuple() public {
+  function testAddNewDealComponentAsTuple() public {
     // bytes32 ilk_,
     // address token_,
     // address urn_,
@@ -426,7 +426,7 @@ contract RwaRegistryTest is Test {
     assertEq(actualVariant, variant_, "Component variant mismatch");
   }
 
-  function testFuzzUpdateDealComponent() public {
+  function testUpdateDealComponent() public {
     // bytes32 ilk_,
     // address token_,
     // uint256 variant_
@@ -493,7 +493,7 @@ contract RwaRegistryTest is Test {
     reg.getComponent(ilk_, "urn");
   }
 
-  function testFuzzUpdateDealComponentAsTuple() public {
+  function testUpdateDealComponentAsTuple() public {
     // bytes32 ilk_,
     // address token_,
     // uint256 variant_
@@ -589,7 +589,7 @@ contract RwaRegistryTest is Test {
     reg.getComponentTuple(ilk_, "urn");
   }
 
-  function testFuzzRevertUnautorizedUpdateDeal() public {
+  function testRevertUnautorizedUpdateDeal() public {
     // address sender_,
     // bytes32 ilk_,
     // address token_
@@ -612,7 +612,7 @@ contract RwaRegistryTest is Test {
     reg.file(ilk_, "component", RwaRegistry.Component({name: "token", addr: address(0x1337), variant: 1337}));
   }
 
-  function testFuzzFinalizeComponent() public {
+  function testFinalizeComponent() public {
     // bytes32 ilk_
 
     bytes32 ilk_ = "RWA1337-A";
@@ -644,7 +644,7 @@ contract RwaRegistryTest is Test {
     reg.finalize(wrongIlk);
   }
 
-  function testFuzzRevertUpdateFinalizedComponent() public {
+  function testRevertUpdateFinalizedComponent() public {
     // bytes32 ilk_
 
     bytes32 ilk_ = "RWA1337-A";
@@ -659,7 +659,7 @@ contract RwaRegistryTest is Test {
     reg.file(ilk_, "component", RwaRegistry.Component({name: "token", addr: address(0x2448), variant: 2}));
   }
 
-  function testFuzzRevertUpdateFinalizedComponentAsTuple() public {
+  function testRevertUpdateFinalizedComponentAsTuple() public {
     // bytes32 ilk_
 
     bytes32 ilk_ = "RWA1337-A";

--- a/src/RwaRegistry.t.sol
+++ b/src/RwaRegistry.t.sol
@@ -20,5 +20,35 @@ import "forge-std/Test.sol";
 import {RwaRegistry} from "./RwaRegistry.sol";
 
 contract RwaRegistryTest is Test {
-  function setUp() public {}
+  RwaRegistry internal reg;
+
+  function setUp() public {
+    reg = new RwaRegistry();
+  }
+
+  /*//////////////////////////////////
+     Supported Components Management
+  //////////////////////////////////*/
+
+  function testShouldAddDefaultSupportedComponentsDuringDeployment() public {
+    assertEq(reg.isSupportedComponent("token"), 1);
+    assertEq(reg.isSupportedComponent("urn"), 1);
+    assertEq(reg.isSupportedComponent("liquidationOracle"), 1);
+    assertEq(reg.isSupportedComponent("outputConduit"), 1);
+    assertEq(reg.isSupportedComponent("inputConduit"), 1);
+    assertEq(reg.isSupportedComponent("jar"), 1);
+  }
+
+  function testAddSupportedComponent() public {
+    reg.addSupportedComponent("somethingElse");
+
+    assertEq(reg.isSupportedComponent("somethingElse"), 1);
+  }
+
+  function testRevertUnautorizedAddressAddsSupportedComponent() public {
+    vm.expectRevert(RwaRegistry.Unauthorized.selector);
+
+    vm.prank(address(0x1337));
+    reg.addSupportedComponent("anything");
+  }
 }


### PR DESCRIPTION
Implements a registry for RWA deals with support for arbitrary components.

[sc-806]

## Design Considerations

- [x] Gas efficiency is not really a priority, since this registry will be for multi-million vaults with very infrequent updates. It's done on a best-effort fashion, without sacrificing ease of use.
- [x] More components can be added to the registry without breaking backwards-compatibility.
- [x] The registry is append/modify only. It's not possible to remove information from it.
- [x] The registry is optimized for `abicoderv2`, but it should work for consumers which cannot or will not use it.