### PR TITLE
Refactor: apply changes suggested by PECU

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,3 @@
+The copyright holder for the code in this repository is:
+
+© 2022 Dai Foundation <www.daifoundation.org>

--- a/README.md
+++ b/README.md
@@ -39,12 +39,11 @@ Deal components consist of:
 
 - `name: bytes32`: the `camelCased` name of the component. It has to be one of the supported components.
 - `addr: address`: the address of the component, be it a smart contract or an EOA.
-- `variant: uint256`: we have identified
-  early on that components fulfilling the same role may have different implementations. Following the same approach of
-  the [`GemJoin` adapters](https://github.com/makerdao/dss-gem-joins/), each implementation has a numeric suffix
-  identifying it. This allows consumers to know precisely with which implementation they are dealing with when
-  querying the registry. Different components can have different reserved values for variants with special meaning and
-  should be documented below.
+- `variant: uint88`: we have identified early on that components fulfilling the same role may have different
+  implementations. Following the same approach of the [`GemJoin` adapters](https://github.com/makerdao/dss-gem-joins/),
+  each implementation has a numeric suffix identifying it. This allows consumers to know precisely with which
+  implementation they are dealing with when querying the registry. Different components can have different reserved
+  values for variants with special meaning and should be documented below.
 
 ## List of currently supported components
 
@@ -91,11 +90,11 @@ The RWA output conduit, acts as a temporary holder for Dai when it is generated 
 
 **Variants:**
 
-|     #      | Description                                                                                                                                     |
-| :--------: | :---------------------------------------------------------------------------------------------------------------------------------------------- |
-|    `1`     | The base implementation the output conduit. See [`RwaOutputConduit.sol`][rwa-output-conduit]                                                    |
-|    `2`     | Based on `#1`, with a permissioned `push()` method. See [`RwaOutputConduit2.sol`][rwa-output-conduit2]                                          |
-| `uint(-1)` | Not a real conduit. Should be used when Dai is drawn directly into the destination and be treated as an opaque `address`, not a smart contract. |
+|         #          | Description                                                                                                                                     |
+| :----------------: | :---------------------------------------------------------------------------------------------------------------------------------------------- |
+|        `1`         | The base implementation the output conduit. See [`RwaOutputConduit.sol`][rwa-output-conduit]                                                    |
+|        `2`         | Based on `#1`, with a permissioned `push()` method. See [`RwaOutputConduit2.sol`][rwa-output-conduit2]                                          |
+| `type(uint88).max` | Not a real conduit. Should be used when Dai is drawn directly into the destination and be treated as an opaque `address`, not a smart contract. |
 
 [rwa-output-conduit]: https://github.com/clio-finance/mip21-toolkit/blob/master/src/conduits/RwaOutputConduit.sol
 [rwa-output-conduit2]: https://github.com/clio-finance/mip21-toolkit/blob/master/src/conduits/RwaOutputConduit2.sol

--- a/src/RwaRegistry.sol
+++ b/src/RwaRegistry.sol
@@ -334,6 +334,21 @@ contract RwaRegistry {
   /**
    * @notice Returns the list of components associated to `ilk_`.
    * @param ilk_ The ilk name.
+   * @return The list of component names.
+   */
+  function listComponentNamesOf(bytes32 ilk_) external view returns (bytes32[] memory) {
+    Deal storage deal = ilkToDeal[ilk_];
+
+    if (deal.status == DealStatus.NONE) {
+      revert DealDoesNotExist(ilk_);
+    }
+
+    return deal.components;
+  }
+
+  /**
+   * @notice Returns the list of components associated to `ilk_`.
+   * @param ilk_ The ilk name.
    * @return names The list of component names.
    * @return addrs The list of component addresses.
    * @return variants The list of component variants.
@@ -429,7 +444,7 @@ contract RwaRegistry {
     address[] calldata addrs_,
     uint88[] calldata variants_
   ) internal {
-    if (names_.length != addrs_.length || names_.length != variants_.length) {
+    if (!(names_.length == addrs_.length && names_.length == variants_.length)) {
       revert MismatchingComponentParams();
     }
 

--- a/src/RwaRegistry.sol
+++ b/src/RwaRegistry.sol
@@ -17,9 +17,9 @@
 pragma solidity ^0.8.14;
 
 /**
- * @title MIP-21 RWA Registry
+ * @title RWA Registry
  * @author Henrique Barcelos <henrique@clio.finance>
- * @notice Registry for different MIP-21 deals onboarded into MCD.
+ * @notice Registry for different deals onboarded into MCD.
  */
 contract RwaRegistry {
   /**
@@ -41,7 +41,7 @@ contract RwaRegistry {
     mapping(bytes32 => Component) nameToComponent; // Associate a component name to its params. nameToComponent[componentName].
   }
 
-  // MIP-21 Architeture Components. `name` is not needed in storage because it is the mapping key.
+  // Architeture Components. `name` is not needed in storage because it is the mapping key.
   struct Component {
     bool exists; // Whether the component exists or not.
     address addr; // Address of the component.
@@ -219,7 +219,7 @@ contract RwaRegistry {
 
   /**
    * @notice Adds a supported component name to the registry.
-   * @dev Adds a new type of MIP-21 component that should be supported.
+   * @dev Adds a new type of component that should be supported.
    * @param name_ The "pascalCased" name of the component.
    */
   function addSupportedComponent(bytes32 name_) external auth {
@@ -416,7 +416,7 @@ contract RwaRegistry {
   }
 
   /**
-   * @notice Adds the MIP-21 components associated to a deal identified by `ilk_`.
+   * @notice Adds the components associated to a deal identified by `ilk_`.
    * @dev All array arguments must have the same length and order.
    * @param ilk_ The ilk name.
    * @param names_ The list of component names.

--- a/src/RwaRegistry.sol
+++ b/src/RwaRegistry.sol
@@ -289,7 +289,6 @@ contract RwaRegistry {
 
   /**
    * @notice Updates the components of an existing `ilk_`.
-   * @dev Uses only primitive types as input.
    * @param ilk_ The ilk name.
    * @param what_ What is being changed. One of ["component"].
    * @param componentName_ The name of the component. Must be one of the supported ones.
@@ -344,7 +343,6 @@ contract RwaRegistry {
 
   /**
    * @notice Returns the list of components associated to `ilk_`.
-   * @dev Returns a tuple of primitive types arrays for consumers incompatible with abicoderv2.
    * @param ilk_ The ilk name.
    * @return names The list of component names.
    * @return addrs The list of component addresses.
@@ -382,7 +380,6 @@ contract RwaRegistry {
   /**
    * @notice Gets a specific component from a deal identified by `ilk`.
    * @dev It will revert if the deal or the component does not exist.
-   * @dev Returns a tuple of primitive types arrays for consumers incompatible with abicoderv2.
    * @param ilk_ The ilk name.
    * @param componentName_ The name of the component.
    * @return addr The component address.

--- a/src/RwaRegistry.sol
+++ b/src/RwaRegistry.sol
@@ -1,18 +1,4 @@
-// Copyright (C) 2022 Dai Foundation
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.14;
 

--- a/src/RwaRegistry.t.sol
+++ b/src/RwaRegistry.t.sol
@@ -231,6 +231,41 @@ contract RwaRegistryTest is Test {
     assertEq(actualVariants.length, 0, "Variant list is not empty");
   }
 
+  function testListAllDealComponentNames() public {
+    // bytes32 ilk_,
+    // addrres urn_,
+    // addrres liquidationOracle_
+
+    bytes32 ilk_ = "RWA1337-A";
+    address urn_ = address(0x1337);
+    address liquidationOracle_ = address(0x2448);
+
+    bytes32[] memory originalNames = new bytes32[](2);
+    address[] memory originalAddrs = new address[](2);
+    uint88[] memory originalVariants = new uint88[](2);
+    originalNames[0] = "urn";
+    originalAddrs[0] = urn_;
+    originalVariants[0] = 1;
+    originalNames[1] = "liquidationOracle";
+    originalAddrs[1] = liquidationOracle_;
+    originalVariants[1] = 1;
+    reg.add(ilk_, originalNames, originalAddrs, originalVariants);
+
+    bytes32[] memory actualNames = reg.listComponentNamesOf(ilk_);
+
+    assertEq(actualNames[0], originalNames[0]);
+    assertEq(actualNames[1], originalNames[1]);
+  }
+
+  function testRevertListComponentNamesOfUnexistingDeal() public {
+    // bytes32 ilk_
+
+    bytes32 ilk_ = "RWA1337-A";
+
+    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.DealDoesNotExist.selector, ilk_));
+    reg.listComponentNamesOf(ilk_);
+  }
+
   function testAddDealWithNoComponents() public {
     // bytes32 ilk_
 
@@ -276,28 +311,22 @@ contract RwaRegistryTest is Test {
   }
 
   function testListAllDealIlks() public {
-    // bytes32 ilk1_, bytes32 ilk2_
-    // if (ilk1_ == ilk2_) {
-    //   return;
-    // }
+    // bytes32 ilk0_, bytes32 ilk1_
+    // vm.assume(ilk0_ != ilk1_);
 
-    bytes32 ilk1_ = "RWA1337-A";
-    bytes32 ilk2_ = "RWA2448-A";
+    bytes32 ilk0_ = "RWA1337-A";
+    bytes32 ilk1_ = "RWA2448-A";
 
+    reg.add(ilk0_);
     reg.add(ilk1_);
-    reg.add(ilk2_);
 
     bytes32[] memory actualIlks = reg.list();
 
-    bytes32[] memory expectedIlks = new bytes32[](2);
-    expectedIlks[0] = ilk1_;
-    expectedIlks[1] = ilk2_;
-
-    assertEq(actualIlks[0], expectedIlks[0]);
-    assertEq(actualIlks[1], expectedIlks[1]);
+    assertEq(actualIlks[0], ilk0_);
+    assertEq(actualIlks[1], ilk1_);
   }
 
-  function testiCountAllDealIlks() public {
+  function testCountAllDealIlks() public {
     // bytes32[] memory ilks_
     // if (ilks_.length == 0) {
     //   return;

--- a/src/RwaRegistry.t.sol
+++ b/src/RwaRegistry.t.sol
@@ -47,8 +47,7 @@ contract RwaRegistryTest is Test {
   //////////////////////////////////*/
 
   function testAddDefaultSupportedComponentsDuringDeployment() public {
-    assertEq(reg.listSupportedComponents().length, 6);
-    assertEq(reg.isSupportedComponent("token"), 1);
+    assertEq(reg.listSupportedComponents().length, 5);
     assertEq(reg.isSupportedComponent("urn"), 1);
     assertEq(reg.isSupportedComponent("liquidationOracle"), 1);
     assertEq(reg.isSupportedComponent("outputConduit"), 1);
@@ -91,7 +90,6 @@ contract RwaRegistryTest is Test {
 
   function testAddDealAndComponents() public {
     // bytes32 ilk_,
-    // address token_,
     // address urn_,
     // address liquidationOracle_,
     // address outputConduit_,
@@ -99,130 +97,79 @@ contract RwaRegistryTest is Test {
     // address jar_
 
     bytes32 ilk_ = "RWA1337-a";
-    address token_ = address(0x1337);
     address urn_ = address(0x2448);
     address liquidationOracle_ = address(0x3559);
     address outputConduit_ = address(0x466a);
     address inputConduit_ = address(0x577b);
     address jar_ = address(0x688c);
 
-    RwaRegistry.Component[] memory expectedComponents = new RwaRegistry.Component[](6);
+    bytes32[] memory names = new bytes32[](5);
+    names[0] = "urn";
+    names[1] = "liquidationOracle";
+    names[2] = "outputConduit";
+    names[3] = "inputConduit";
+    names[4] = "jar";
 
-    expectedComponents[0] = RwaRegistry.Component({name: "token", addr: token_, variant: 1});
-    expectedComponents[1] = RwaRegistry.Component({name: "urn", addr: urn_, variant: 1});
-    expectedComponents[2] = RwaRegistry.Component({name: "liquidationOracle", addr: liquidationOracle_, variant: 1});
-    expectedComponents[3] = RwaRegistry.Component({name: "outputConduit", addr: outputConduit_, variant: 1});
-    expectedComponents[4] = RwaRegistry.Component({name: "inputConduit", addr: inputConduit_, variant: 1});
-    expectedComponents[5] = RwaRegistry.Component({name: "jar", addr: jar_, variant: 1});
+    address[] memory addrs = new address[](5);
+    addrs[0] = urn_;
+    addrs[1] = liquidationOracle_;
+    addrs[2] = outputConduit_;
+    addrs[3] = inputConduit_;
+    addrs[4] = jar_;
 
-    reg.add(ilk_, expectedComponents);
-
-    (RwaRegistry.DealStatus status, ) = reg.ilkToDeal(ilk_);
-    RwaRegistry.Component[] memory actualComponents = reg.listComponentsOf(ilk_);
-
-    assertEq(uint256(status), uint256(RwaRegistry.DealStatus.ACTIVE));
-
-    assertEq(actualComponents[0].name, expectedComponents[0].name, "Component mismatch: token");
-    assertEq(actualComponents[1].name, expectedComponents[1].name, "Component mismatch: urn");
-    assertEq(actualComponents[2].name, expectedComponents[2].name, "Component mismatch: liquidationOracle");
-    assertEq(actualComponents[3].name, expectedComponents[3].name, "Component mismatch: outputConduit");
-    assertEq(actualComponents[4].name, expectedComponents[4].name, "Component mismatch: inputConduit");
-    assertEq(actualComponents[5].name, expectedComponents[5].name, "Component mismatch: jar");
-
-    assertEq(actualComponents[0].addr, expectedComponents[0].addr, "Component address mismatch: token");
-    assertEq(actualComponents[1].addr, expectedComponents[1].addr, "Component address mismatch: urn");
-    assertEq(actualComponents[2].addr, expectedComponents[2].addr, "Component address mismatch: liquidationOracle");
-    assertEq(actualComponents[3].addr, expectedComponents[3].addr, "Component address mismatch: outputConduit");
-    assertEq(actualComponents[4].addr, expectedComponents[4].addr, "Component address mismatch: inputConduit");
-    assertEq(actualComponents[5].addr, expectedComponents[5].addr, "Component address mismatch: jar");
-
-    assertEq(actualComponents[0].variant, expectedComponents[0].variant, "Component variant mismatch: token");
-    assertEq(actualComponents[1].variant, expectedComponents[1].variant, "Component variant mismatch: urn");
-    assertEq(
-      actualComponents[2].variant,
-      expectedComponents[2].variant,
-      "Component variant mismatch: liquidationOracle"
-    );
-    assertEq(actualComponents[3].variant, expectedComponents[3].variant, "Component variant mismatch: outputConduit");
-    assertEq(actualComponents[4].variant, expectedComponents[4].variant, "Component variant mismatch: inputConduit");
-    assertEq(actualComponents[5].variant, expectedComponents[5].variant, "Component variant mismatch: jar");
-  }
-
-  function testRevertAddDealWithUnsupportedComponent() public {
-    // bytes32 ilk_,
-    // address token_,
-    // address someAddr,
-
-    bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x1337);
-    address someAddr_ = address(0x2448);
-
-    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](2);
-
-    components[0] = RwaRegistry.Component({name: "token", addr: token_, variant: 1});
-    components[1] = RwaRegistry.Component({name: "something", addr: someAddr_, variant: 1});
-
-    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.UnsupportedComponent.selector, components[1].name));
-    reg.add(ilk_, components);
-  }
-
-  function testAddDealAndComponentsAsTuple() public {
-    // bytes32 ilk_,
-    // address token_,
-    // address urn_
-
-    bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x1337);
-    address urn_ = address(0x2448);
-
-    bytes32[] memory names = new bytes32[](2);
-    names[0] = "token";
-    names[1] = "urn";
-
-    address[] memory addrs = new address[](2);
-    addrs[0] = token_;
-    addrs[1] = urn_;
-
-    uint256[] memory variants = new uint256[](2);
+    uint88[] memory variants = new uint88[](5);
     variants[0] = 1;
     variants[1] = 1;
+    variants[2] = 1;
+    variants[3] = 1;
+    variants[4] = 1;
 
     reg.add(ilk_, names, addrs, variants);
 
     (RwaRegistry.DealStatus status, ) = reg.ilkToDeal(ilk_);
-    (bytes32[] memory actualNames, address[] memory actualAddrs, uint256[] memory actualVariants) = reg
-      .listComponentsTupleOf(ilk_);
+    (bytes32[] memory actualNames, address[] memory actualAddrs, uint88[] memory actualVariants) = reg.listComponentsOf(
+      ilk_
+    );
 
     assertEq(uint256(status), uint256(RwaRegistry.DealStatus.ACTIVE));
 
-    assertEq(actualNames[0], names[0], "Component mismatch: token");
-    assertEq(actualNames[1], names[1], "Component mismatch: urn");
+    assertEq(actualNames[0], names[0], "Component mismatch: urn");
+    assertEq(actualNames[1], names[1], "Component mismatch: liquidationOracle");
+    assertEq(actualNames[2], names[2], "Component mismatch: outputConduit");
+    assertEq(actualNames[3], names[3], "Component mismatch: inputConduit");
+    assertEq(actualNames[4], names[4], "Component mismatch: jar");
 
-    assertEq(actualAddrs[0], addrs[0], "Component address mismatch: token");
-    assertEq(actualAddrs[1], addrs[1], "Component address mismatch: urn");
+    assertEq(actualAddrs[0], addrs[0], "Component address mismatch: urn");
+    assertEq(actualAddrs[1], addrs[1], "Component address mismatch: liquidationOracle");
+    assertEq(actualAddrs[2], addrs[2], "Component address mismatch: outputConduit");
+    assertEq(actualAddrs[3], addrs[3], "Component address mismatch: inputConduit");
+    assertEq(actualAddrs[4], addrs[4], "Component address mismatch: jar");
 
-    assertEq(actualVariants[0], variants[0], "Component variant mismatch: token");
-    assertEq(actualVariants[1], variants[1], "Component variant mismatch: urn");
+    assertEq(actualVariants[0], variants[0], "Component variant mismatch: urn");
+    assertEq(actualVariants[1], variants[1], "Component variant mismatch: liquidationOracle");
+    assertEq(actualVariants[2], variants[2], "Component variant mismatch: outputConduit");
+    assertEq(actualVariants[3], variants[3], "Component variant mismatch: inputConduit");
+    assertEq(actualVariants[4], variants[4], "Component variant mismatch: jar");
   }
 
-  function testRevertAddDealWithUnsupportedComponentAsTuple() public {
+  function testRevertAddDealWithUnsupportedComponent() public {
     // bytes32 ilk_,
-    // address token_,
+    // address urn_,
     // address someAddr,
 
     bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x1337);
+    address urn_ = address(0x1337);
     address someAddr_ = address(0x2448);
 
-    bytes32[] memory names = new bytes32[](2);
-    names[0] = "token";
+    bytes32[] memory names = new bytes32[](5);
+    names[0] = "urn";
     names[1] = "something";
 
-    address[] memory addrs = new address[](2);
-    addrs[0] = token_;
+    address[] memory addrs = new address[](5);
+    addrs[0] = urn_;
     addrs[1] = someAddr_;
 
-    uint256[] memory variants = new uint256[](2);
+    uint88[] memory variants = new uint88[](5);
     variants[0] = 1;
     variants[1] = 1;
 
@@ -230,23 +177,23 @@ contract RwaRegistryTest is Test {
     reg.add(ilk_, names, addrs, variants);
   }
 
-  function testRevertAddDealWithComponentsAsTupleWithMismatchingParams() public {
+  function testRevertAddDealWithComponentsWithMismatchingParams() public {
     // bytes32 ilk_,
-    // address token_,
     // address urn_
+    // address liquidationOracle_,
 
     bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x1337);
-    address urn_ = address(0x2448);
+    address urn_ = address(0x1337);
+    address liquidationOracle_ = address(0x2448);
 
     bytes32[] memory names = new bytes32[](1);
-    names[0] = "token";
+    names[0] = "urn";
 
     address[] memory addrs = new address[](2);
-    addrs[0] = token_;
-    addrs[1] = urn_;
+    addrs[0] = urn_;
+    addrs[1] = liquidationOracle_;
 
-    uint256[] memory variants = new uint256[](2);
+    uint88[] memory variants = new uint88[](2);
     variants[0] = 1;
     variants[1] = 1;
 
@@ -263,28 +210,25 @@ contract RwaRegistryTest is Test {
     reg.listComponentsOf(ilk_);
   }
 
-  function testRevertListComponentsTupleOfUnexistingDeal() public {
-    // bytes32 ilk_
-
-    bytes32 ilk_ = "RWA1337-A";
-
-    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.DealDoesNotExist.selector, ilk_));
-    reg.listComponentsTupleOf(ilk_);
-  }
-
   function testAddDealWithEmptyComponentList() public {
     // bytes32 ilk_
 
     bytes32 ilk_ = "RWA1337-A";
 
-    RwaRegistry.Component[] memory components;
-    reg.add(ilk_, components);
+    bytes32[] memory names;
+    address[] memory addrs;
+    uint88[] memory variants;
+    reg.add(ilk_, names, addrs, variants);
 
     (RwaRegistry.DealStatus status, ) = reg.ilkToDeal(ilk_);
-    RwaRegistry.Component[] memory actualComponents = reg.listComponentsOf(ilk_);
+    (bytes32[] memory actualNames, address[] memory actualAddrs, uint88[] memory actualVariants) = reg.listComponentsOf(
+      ilk_
+    );
 
     assertEq(uint256(status), uint256(RwaRegistry.DealStatus.ACTIVE));
-    assertTrue(actualComponents.length == 0);
+    assertEq(actualNames.length, 0, "Name list is not empty");
+    assertEq(actualAddrs.length, 0, "Address list is not empty");
+    assertEq(actualVariants.length, 0, "Variant list is not empty");
   }
 
   function testAddDealWithNoComponents() public {
@@ -295,10 +239,13 @@ contract RwaRegistryTest is Test {
     reg.add(ilk_);
 
     (RwaRegistry.DealStatus status, ) = reg.ilkToDeal(ilk_);
-    RwaRegistry.Component[] memory actualComponents = reg.listComponentsOf(ilk_);
+
+    (bytes32[] memory names, address[] memory addrs, uint88[] memory variants) = reg.listComponentsOf(ilk_);
 
     assertEq(uint256(status), uint256(RwaRegistry.DealStatus.ACTIVE));
-    assertTrue(actualComponents.length == 0);
+    assertEq(names.length, 0, "Name list is not empty");
+    assertEq(addrs.length, 0, "Address list is not empty");
+    assertEq(variants.length, 0, "Variant list is not empty");
   }
 
   function testRevertAddExistingDeal() public {
@@ -314,7 +261,6 @@ contract RwaRegistryTest is Test {
   function testRevertUnautorizedAddDeal() public {
     // address sender_,
     // bytes32 ilk_,
-    // address token_
 
     // if (sender_ == address(this)) {
     //   return;
@@ -322,15 +268,11 @@ contract RwaRegistryTest is Test {
 
     address sender_ = address(0x1337);
     bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x2448);
-
-    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
-    components[0] = RwaRegistry.Component({name: "token", addr: token_, variant: 1});
 
     vm.expectRevert(RwaRegistry.Unauthorized.selector);
     vm.prank(sender_);
 
-    reg.add(ilk_, components);
+    reg.add(ilk_);
   }
 
   function testListAllDealIlks() public {
@@ -376,223 +318,110 @@ contract RwaRegistryTest is Test {
     uint256 count = reg.count();
 
     uint256 expected = ilks_.length - duplicates;
-    assertEq(count, expected);
+    assertEq(count, expected, "Wrong count");
   }
 
-  function testAddNewDealComponent() public {
+  function testAddNewComponentToDeal() public {
     // bytes32 ilk_,
-    // address token_,
     // address urn_,
-    // uint256 variant_
+    // uint88 variant_
 
     bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x1337);
     address urn_ = address(0x3549);
-    uint256 variant_ = 0x2830;
-
-    RwaRegistry.Component memory originalComponent = RwaRegistry.Component({name: "token", addr: token_, variant: 1});
-    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
-    components[0] = originalComponent;
-    reg.add(ilk_, components);
-
-    RwaRegistry.Component memory newComponent = RwaRegistry.Component({name: "urn", addr: urn_, variant: variant_});
-    reg.file(ilk_, "component", newComponent);
-
-    RwaRegistry.Component memory actualComponent = reg.getComponent(ilk_, "urn");
-    assertEq(actualComponent.addr, newComponent.addr, "Component address mismatch");
-    assertEq(actualComponent.variant, newComponent.variant, "Component variant mismatch");
-  }
-
-  function testAddNewDealComponentAsTuple() public {
-    // bytes32 ilk_,
-    // address token_,
-    // address urn_,
-    // uint256 variant_
-
-    bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x1337);
-    address urn_ = address(0x3549);
-    uint256 variant_ = 0x2830;
-
-    RwaRegistry.Component memory originalComponent = RwaRegistry.Component({name: "token", addr: token_, variant: 1});
-    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
-    components[0] = originalComponent;
-    reg.add(ilk_, components);
+    uint88 variant_ = 0x2830;
+    reg.add(ilk_);
 
     reg.file(ilk_, "component", "urn", urn_, variant_);
 
-    (, address actualAddr, uint256 actualVariant) = reg.getComponentTuple(ilk_, "urn");
-    assertEq(actualAddr, urn_, "Component address mismatch");
-    assertEq(actualVariant, variant_, "Component variant mismatch");
+    (address addr, uint88 variant) = reg.getComponent(ilk_, "urn");
+    assertEq(addr, urn_, "Component address mismatch");
+    assertEq(variant, variant_, "Component variant mismatch");
   }
 
   function testUpdateDealComponent() public {
     // bytes32 ilk_,
-    // address token_,
-    // uint256 variant_
+    // address urn_,
+    // uint88 variant_
 
     bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x2448);
-    uint256 variant_ = 0x2830;
+    address urn_ = address(0x3549);
 
-    RwaRegistry.Component memory originalComponent = RwaRegistry.Component({
-      name: "token",
-      addr: address(0x1337),
-      variant: 1
-    });
-    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
-    components[0] = originalComponent;
-    reg.add(ilk_, components);
+    bytes32[] memory originalNames = new bytes32[](1);
+    address[] memory originalAddrs = new address[](1);
+    uint88[] memory originalVariants = new uint88[](1);
+    originalNames[0] = "urn";
+    originalAddrs[0] = urn_;
+    originalVariants[0] = 1;
+    reg.add(ilk_, originalNames, originalAddrs, originalVariants);
 
-    RwaRegistry.Component memory expectedComponent = RwaRegistry.Component({
-      name: "token",
-      addr: token_,
-      variant: variant_
-    });
-    reg.file(ilk_, "component", expectedComponent);
+    uint88 variant_ = 0x2830;
+    reg.file(ilk_, "component", "urn", urn_, variant_);
 
-    RwaRegistry.Component memory actualComponent = reg.getComponent(ilk_, "token");
-    assertEq(actualComponent.addr, expectedComponent.addr, "Component address mismatch");
-    assertEq(actualComponent.variant, expectedComponent.variant, "Component variant mismatch");
+    (, uint88 updatedVariant) = reg.getComponent(ilk_, "urn");
+    assertEq(updatedVariant, variant_, "Component variant mismatch");
   }
 
   function testReverGetComponentForUnexistingDeal() public {
     // bytes32 ilk_,
-    // address token_,
-    // uint256 variant_
+    // address urn_,
+    // uint88 variant_
 
     bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x2448);
-    uint256 variant_ = 0x2830;
-
-    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: token_, variant: variant_});
-    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
-    components[0] = component;
-    reg.add(ilk_, components);
+    address urn_ = address(0x3549);
+    bytes32[] memory originalNames = new bytes32[](1);
+    address[] memory originalAddrs = new address[](1);
+    uint88[] memory originalVariants = new uint88[](1);
+    originalNames[0] = "urn";
+    originalAddrs[0] = urn_;
+    originalVariants[0] = 1;
+    reg.add(ilk_, originalNames, originalAddrs, originalVariants);
 
     bytes32 wrongIlk = "RWA2448-A";
     vm.expectRevert(abi.encodeWithSelector(RwaRegistry.DealDoesNotExist.selector, wrongIlk));
-    reg.getComponent(wrongIlk, "token");
+    reg.getComponent(wrongIlk, "urn");
   }
 
-  function testReverGetUnexistentComponentForExistingDeal() public {
+  function testRevertGetUnexistentComponentForExistingDeal() public {
     // bytes32 ilk_,
-    // address token_,
-    // uint256 variant_
+    // address urn_,
+    // uint88 variant_
 
     bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x2448);
-    uint256 variant_ = 0x2830;
+    address urn_ = address(0x3549);
+    bytes32[] memory originalNames = new bytes32[](1);
+    address[] memory originalAddrs = new address[](1);
+    uint88[] memory originalVariants = new uint88[](1);
+    originalNames[0] = "urn";
+    originalAddrs[0] = urn_;
+    originalVariants[0] = 1;
+    reg.add(ilk_, originalNames, originalAddrs, originalVariants);
 
-    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: token_, variant: variant_});
-    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
-    components[0] = component;
-    reg.add(ilk_, components);
-
-    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.ComponentDoesNotExist.selector, ilk_, bytes32("urn")));
-    reg.getComponent(ilk_, "urn");
-  }
-
-  function testUpdateDealComponentAsTuple() public {
-    // bytes32 ilk_,
-    // address token_,
-    // uint256 variant_
-
-    bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x2448);
-    uint256 variant_ = 0x2830;
-
-    RwaRegistry.Component memory originalComponent = RwaRegistry.Component({
-      name: "token",
-      addr: address(0x1337),
-      variant: 1
-    });
-    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
-    components[0] = originalComponent;
-    reg.add(ilk_, components);
-
-    reg.file(ilk_, "component", "token", token_, variant_);
-
-    (, address actualAddr, uint256 actualVariant) = reg.getComponentTuple(ilk_, "token");
-    assertEq(actualAddr, token_, "Component address mismatch");
-    assertEq(actualVariant, variant_, "Component variant mismatch");
+    vm.expectRevert(
+      abi.encodeWithSelector(RwaRegistry.ComponentDoesNotExist.selector, ilk_, bytes32("liquidationOracle"))
+    );
+    reg.getComponent(ilk_, "liquidationOracle");
   }
 
   function testReverUpdateUnexistingParameter() public {
     // bytes32 ilk_,
-    // address token_,
-    // uint256 variant_
+    // address urn_,
+    // uint88 variant_
 
     bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x2448);
-    uint256 variant_ = 0x2830;
-
+    address urn_ = address(0x2448);
+    uint88 variant_ = 0x2830;
     reg.add(ilk_);
 
     vm.expectRevert(
       abi.encodeWithSelector(RwaRegistry.UnsupportedParameter.selector, ilk_, bytes32("unexistingParameter"))
     );
-    reg.file(ilk_, "unexistingParameter", RwaRegistry.Component({name: "token", addr: token_, variant: variant_}));
-  }
-
-  function testReverUpdateUnexistingParameterAsTuple() public {
-    // bytes32 ilk_,
-    // address token_,
-    // uint256 variant_
-
-    bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x2448);
-    uint256 variant_ = 0x2830;
-
-    reg.add(ilk_);
-
-    vm.expectRevert(
-      abi.encodeWithSelector(RwaRegistry.UnsupportedParameter.selector, ilk_, bytes32("unexistingParameter"))
-    );
-    reg.file(ilk_, "unexistingParameter", "token", token_, variant_);
-  }
-
-  function testReverGetComponentAsTupleForUnexistingDeal() public {
-    // bytes32 ilk_,
-    // address token_,
-    // uint256 variant_
-
-    bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x2448);
-    uint256 variant_ = 0x2830;
-
-    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: token_, variant: variant_});
-    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
-    components[0] = component;
-    reg.add(ilk_, components);
-
-    bytes32 wrongIlk = "RWA2448-A";
-    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.DealDoesNotExist.selector, wrongIlk));
-    reg.getComponentTuple(wrongIlk, "token");
-  }
-
-  function testReverGetUnexistentComponentAsTupleForExistingDeal() public {
-    // bytes32 ilk_,
-    // address token_,
-    // uint256 variant_
-
-    bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x2448);
-    uint256 variant_ = 0x2830;
-
-    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: token_, variant: variant_});
-    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
-    components[0] = component;
-    reg.add(ilk_, components);
-
-    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.ComponentDoesNotExist.selector, ilk_, bytes32("urn")));
-    reg.getComponentTuple(ilk_, "urn");
+    reg.file(ilk_, "unexistingParameter", "urn", urn_, variant_);
   }
 
   function testRevertUnautorizedUpdateDeal() public {
     // address sender_,
     // bytes32 ilk_,
-    // address token_
+    // address urn_
 
     // if (sender_ == address(this)) {
     //   return;
@@ -600,27 +429,33 @@ contract RwaRegistryTest is Test {
 
     address sender_ = address(0x1337);
     bytes32 ilk_ = "RWA1337-A";
-    address token_ = address(0x2448);
-
-    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
-    components[0] = RwaRegistry.Component({name: "token", addr: token_, variant: 1});
-    reg.add(ilk_, components);
+    address urn_ = address(0x3549);
+    bytes32[] memory originalNames = new bytes32[](1);
+    address[] memory originalAddrs = new address[](1);
+    uint88[] memory originalVariants = new uint88[](1);
+    originalNames[0] = "urn";
+    originalAddrs[0] = urn_;
+    originalVariants[0] = 1;
+    reg.add(ilk_, originalNames, originalAddrs, originalVariants);
 
     vm.expectRevert(RwaRegistry.Unauthorized.selector);
     vm.prank(sender_);
 
-    reg.file(ilk_, "component", RwaRegistry.Component({name: "token", addr: address(0x1337), variant: 1337}));
+    reg.file(ilk_, "component", "urn", address(0x1337), 1337);
   }
 
   function testFinalizeComponent() public {
     // bytes32 ilk_
 
     bytes32 ilk_ = "RWA1337-A";
-
-    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: address(0x1337), variant: 1});
-    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
-    components[0] = component;
-    reg.add(ilk_, components);
+    address urn_ = address(0x3549);
+    bytes32[] memory originalNames = new bytes32[](1);
+    address[] memory originalAddrs = new address[](1);
+    uint88[] memory originalVariants = new uint88[](1);
+    originalNames[0] = "urn";
+    originalAddrs[0] = urn_;
+    originalVariants[0] = 1;
+    reg.add(ilk_, originalNames, originalAddrs, originalVariants);
 
     reg.finalize(ilk_);
 
@@ -633,11 +468,14 @@ contract RwaRegistryTest is Test {
     // bytes32 ilk_
 
     bytes32 ilk_ = "RWA1337-A";
-
-    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: address(0x1337), variant: 1});
-    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
-    components[0] = component;
-    reg.add(ilk_, components);
+    address urn_ = address(0x3549);
+    bytes32[] memory originalNames = new bytes32[](1);
+    address[] memory originalAddrs = new address[](1);
+    uint88[] memory originalVariants = new uint88[](1);
+    originalNames[0] = "urn";
+    originalAddrs[0] = urn_;
+    originalVariants[0] = 1;
+    reg.add(ilk_, originalNames, originalAddrs, originalVariants);
 
     bytes32 wrongIlk = "RWA2448-A";
     vm.expectRevert(abi.encodeWithSelector(RwaRegistry.DealIsNotActive.selector, wrongIlk));
@@ -648,29 +486,17 @@ contract RwaRegistryTest is Test {
     // bytes32 ilk_
 
     bytes32 ilk_ = "RWA1337-A";
-
-    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: address(0x1337), variant: 1});
-    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
-    components[0] = component;
-    reg.add(ilk_, components);
+    address urn_ = address(0x3549);
+    bytes32[] memory originalNames = new bytes32[](1);
+    address[] memory originalAddrs = new address[](1);
+    uint88[] memory originalVariants = new uint88[](1);
+    originalNames[0] = "urn";
+    originalAddrs[0] = urn_;
+    originalVariants[0] = 1;
+    reg.add(ilk_, originalNames, originalAddrs, originalVariants);
     reg.finalize(ilk_);
 
     vm.expectRevert(abi.encodeWithSelector(RwaRegistry.DealIsNotActive.selector, ilk_));
-    reg.file(ilk_, "component", RwaRegistry.Component({name: "token", addr: address(0x2448), variant: 2}));
-  }
-
-  function testRevertUpdateFinalizedComponentAsTuple() public {
-    // bytes32 ilk_
-
-    bytes32 ilk_ = "RWA1337-A";
-
-    RwaRegistry.Component memory component = RwaRegistry.Component({name: "token", addr: address(0x1337), variant: 1});
-    RwaRegistry.Component[] memory components = new RwaRegistry.Component[](1);
-    components[0] = component;
-    reg.add(ilk_, components);
-    reg.finalize(ilk_);
-
-    vm.expectRevert(abi.encodeWithSelector(RwaRegistry.DealIsNotActive.selector, ilk_));
-    reg.file(ilk_, "component", "token", address(0x2448), 2);
+    reg.file(ilk_, "component", "urn", address(0x2448), 2);
   }
 }

--- a/src/RwaRegistry.t.sol
+++ b/src/RwaRegistry.t.sol
@@ -1,18 +1,4 @@
-// Copyright (C) 2022 Dai Foundation
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.14;
 


### PR DESCRIPTION
- [x] Remove the previous `Component` struct and use tuples instead.
  - Removes a lot of duplicated code and makes it easier to consume because consumers don't need to now about the custom struct type.
- [x] Make the stored component to fit into a single storage slot to improve gas usage.
- [x] Remove the `token` component, as it overlaps with information already stored in the Ilk Registry.
- [x] Add method to list only the component names of a deal.
